### PR TITLE
Add option for parallel feature extraction

### DIFF
--- a/src/main/groovy/cz/siret/prank/features/PrankFeatureExtractor.groovy
+++ b/src/main/groovy/cz/siret/prank/features/PrankFeatureExtractor.groovy
@@ -11,11 +11,14 @@ import cz.siret.prank.features.implementation.table.ResidueTableFeature
 import cz.siret.prank.features.weight.WeightFun
 import cz.siret.prank.geom.Atoms
 import cz.siret.prank.geom.Struct
+import groovyx.gpars.GParsPool
+import java.util.concurrent.ConcurrentHashMap
 import cz.siret.prank.geom.samplers.PointSampler
 import cz.siret.prank.geom.samplers.SampledPoints
 import cz.siret.prank.program.PrankException
 import cz.siret.prank.program.params.Parametrized
 import groovy.transform.CompileStatic
+import groovy.transform.TypeCheckingMode
 import groovy.util.logging.Slf4j
 import org.biojava.nbio.structure.Atom
 
@@ -52,7 +55,7 @@ class PrankFeatureExtractor extends FeatureExtractor<PrankFeatureVector> impleme
     /**
      * Feature vectors that are first calculated for atoms and then (projected to SAS points)
      */
-    private Map<Integer, PrankFeatureVector> surfaceAtomVectors = new HashMap<>()
+    private Map<Integer, PrankFeatureVector> surfaceAtomVectors = new ConcurrentHashMap<>()
 
     /**
      * deep layer of atoms under the protein surface
@@ -262,12 +265,14 @@ class PrankFeatureExtractor extends FeatureExtractor<PrankFeatureVector> impleme
 
 //===========================================================================================================//
 
+    @CompileStatic(TypeCheckingMode.SKIP)
     void preCalculateVectorsForAtoms(Atoms atoms) {
         log.debug "pre-calculating vectors for {} atoms", atoms.count
-        
-        for (Atom a : atoms.list) {
-            FeatureVector p = calcAtomVector(a)
-            surfaceAtomVectors.put(a.PDBserial, p)
+        GParsPool.withPool(params.fe_threads) {
+            atoms.list.eachParallel { Atom a ->
+                FeatureVector p = calcAtomVector(a)
+                surfaceAtomVectors.put(a.PDBserial, p)
+            }
         }
     }
 

--- a/src/main/groovy/cz/siret/prank/prediction/pockets/rescorers/ModelBasedRescorer.groovy
+++ b/src/main/groovy/cz/siret/prank/prediction/pockets/rescorers/ModelBasedRescorer.groovy
@@ -15,7 +15,9 @@ import cz.siret.prank.prediction.pockets.PointScoreCalculator
 import cz.siret.prank.prediction.transformation.ScoreTransformer
 import cz.siret.prank.program.ml.Model
 import cz.siret.prank.program.params.Parametrized
+import groovyx.gpars.GParsPool
 import groovy.transform.CompileStatic
+import groovy.transform.TypeCheckingMode
 import groovy.util.logging.Slf4j
 import org.biojava.nbio.structure.Atom
 
@@ -57,6 +59,7 @@ class ModelBasedRescorer extends PocketRescorer implements Parametrized  {
      * @param prediction
      */
     @Override
+    @CompileStatic(TypeCheckingMode.SKIP)
     void rescorePockets(Prediction prediction, ProcessedItemContext context) {
 
         FeatureExtractor proteinExtractor = extractorFactory.createPrototypeForProtein(prediction.protein, context)
@@ -76,13 +79,15 @@ class ModelBasedRescorer extends PocketRescorer implements Parametrized  {
 
             int n_points = extractor.sampledPoints.points.count
             labeledPoints = new ArrayList<>(n_points)
-            for (Atom point : extractor.sampledPoints.points) {
+            extractor.sampledPoints.points.each { Atom point ->
                 labeledPoints.add(new LabeledPoint(point))
             }
 
-            List<FeatureVector> vectors = new ArrayList<>(n_points)
-            for (LabeledPoint point : labeledPoints) {
-                vectors.add(extractor.calcFeatureVector(point.point))
+            List<FeatureVector> vectors
+            GParsPool.withPool(params.fe_threads) {
+                vectors = labeledPoints.collectParallel { LabeledPoint point ->
+                    extractor.calcFeatureVector(point.point)
+                } as List<FeatureVector>
             }
 
             // classification
@@ -129,6 +134,7 @@ class ModelBasedRescorer extends PocketRescorer implements Parametrized  {
      * Rescore predictions of other methods
      * TODO refactor to use PointScoreCalculator
      */
+    @CompileStatic(TypeCheckingMode.SKIP)
     private void doRescore(Prediction prediction, FeatureExtractor proteinExtractor, InstancePredictor instancePredictor) {
 
         proteinExtractor.prepareProteinPrototypeForPockets()
@@ -142,27 +148,26 @@ class ModelBasedRescorer extends PocketRescorer implements Parametrized  {
             double sum = 0
             double rawSum = 0
 
-            List<LabeledPoint> pocketLabeledPoints = new ArrayList<>(extractor.sampledPoints.points.count)
+            List<LabeledPoint> pocketLabeledPoints
+            GParsPool.withPool(params.fe_threads) {
+                pocketLabeledPoints = extractor.sampledPoints.points.collectParallel { Atom point ->
+                    FeatureVector vector = extractor.calcFeatureVector(point)
+                    double pointScore = instancePredictor.predictPositive(vector)
+                    boolean predicted = applyPointScoreThreshold(pointScore)
+                    boolean observed = false
+                    if (collectStats) {
+                        observed = isPositivePoint(point, ligandAtoms)
+                    }
+                    return new LabeledPoint(point, observed, predicted, pointScore)
+                } as List<LabeledPoint>
+            }
 
-            for (Atom point : extractor.sampledPoints.points) {
-
-                FeatureVector vector = extractor.calcFeatureVector(point)
-
-                // not all classifiers give histogram that sums up to 1
-                double pointScore = instancePredictor.predictPositive(vector)
-                boolean predicted = applyPointScoreThreshold(pointScore)
-                boolean observed = false
-
+            for (LabeledPoint lp : pocketLabeledPoints) {
                 if (collectStats) {
-                    observed = isPositivePoint(point, ligandAtoms)
-                    stats.addPrediction(observed, predicted, pointScore)
+                    stats.addPrediction(lp.observed, lp.predicted, lp.score)
                 }
-
-                pocketLabeledPoints.add(new LabeledPoint(point, observed, predicted, pointScore))
-
-                sum += calculator.transformScore(pointScore)
-
-                rawSum += pointScore // ~ P(ligandable)
+                sum += calculator.transformScore(lp.score)
+                rawSum += lp.score
             }
 
             if (collectPoints) {

--- a/src/main/groovy/cz/siret/prank/program/params/Params.groovy
+++ b/src/main/groovy/cz/siret/prank/program/params/Params.groovy
@@ -359,6 +359,12 @@ class Params {
     int rf_threads = 0
 
     /**
+     * number of threads used for per-protein feature computation (0=use value of threads param)
+     */
+    @RuntimeParam
+    int fe_threads = 0
+
+    /**
      * size of a bag: 1..100% of the dataset
      */
     @ModelParam // training
@@ -1462,8 +1468,13 @@ class Params {
         if (!parallel) {
             threads = 1
             rf_threads = 1
+            fe_threads = 1
         } else if (threads==1) {
             parallel = false
+        }
+
+        if (fe_threads <= 0) {
+            fe_threads = threads
         }
     }
 


### PR DESCRIPTION
## Summary
- add `fe_threads` runtime parameter to control per-protein feature parallelism
- parallelize atom feature precalculation in `PrankFeatureExtractor`
- speed up batch rescoring by parallelizing feature extraction in `ModelBasedRescorer`

## Testing
- `./gradlew test` *(fails: Vectors from no protein were collected)*

------
https://chatgpt.com/codex/tasks/task_e_685384c227b8833292dac04eb4304da0